### PR TITLE
Jack Milton 2102868 22/10/24

### DIFF
--- a/Breakout/Ball.cpp
+++ b/Breakout/Ball.cpp
@@ -84,6 +84,7 @@ void Ball::update(float dt)
         // Adjust position to avoid getting stuck inside the paddle
         _sprite.setPosition(_sprite.getPosition().x, _gameManager->getPaddle()->getBounds().top - 2 * RADIUS);
         IncreaseSpeed();
+        _gameManager->getPaddle()->CollisionWithBall();
     }
 
     // collision with bricks

--- a/Breakout/Ball.cpp
+++ b/Breakout/Ball.cpp
@@ -5,6 +5,8 @@ Ball::Ball(sf::RenderWindow* window, float velocity, GameManager* gameManager)
     : _window(window), _velocity(velocity), _gameManager(gameManager),
     _timeWithPowerupEffect(0.f), _isFireBall(false), _isAlive(true), _direction({1,1})
 {
+    _velocityInitial = VELOCITY;
+    _velocityCumulative = VELOCITY;
     _sprite.setRadius(RADIUS);
     _sprite.setFillColor(sf::Color::Cyan);
     _sprite.setPosition(0, 300);
@@ -23,8 +25,8 @@ void Ball::update(float dt)
     }
     else
     {
-        if (_velocity != VELOCITY)
-            _velocity = VELOCITY;   // reset speed.
+        if (_velocity != _velocityCumulative)
+            _velocity = _velocityCumulative;   // reset speed.
         else
         {
             setFireBall(0);    // disable fireball
@@ -38,6 +40,7 @@ void Ball::update(float dt)
         // Flickering effect
         int flicker = rand() % 50 + 205; // Random value between 205 and 255
         _sprite.setFillColor(sf::Color(flicker, flicker / 2, 0)); // Orange flickering color
+        _velocity = _velocityCumulative * 10;
     }
 
     // Update position with a subtle floating-point error
@@ -65,6 +68,9 @@ void Ball::update(float dt)
         _sprite.setPosition(0, 300);
         _direction = { 1, 1 };
         _gameManager->loseLife();
+        _velocityCumulative = _velocityInitial; 
+        _velocity = _velocityInitial;
+        
     }
 
     // collision with paddle
@@ -77,6 +83,7 @@ void Ball::update(float dt)
 
         // Adjust position to avoid getting stuck inside the paddle
         _sprite.setPosition(_sprite.getPosition().x, _gameManager->getPaddle()->getBounds().top - 2 * RADIUS);
+        IncreaseSpeed();
     }
 
     // collision with bricks
@@ -99,7 +106,7 @@ void Ball::render()
 
 void Ball::setVelocity(float coeff, float duration)
 {
-    _velocity = coeff * VELOCITY;
+    _velocity = coeff * _velocityCumulative;
     _timeWithPowerupEffect = duration;
 }
 
@@ -113,4 +120,10 @@ void Ball::setFireBall(float duration)
     }
     _isFireBall = false;
     _timeWithPowerupEffect = 0.f;    
+}
+
+void Ball::IncreaseSpeed()
+{
+    _velocityCumulative += (_velocityInitial * 0.1f );
+    _velocity = _velocityCumulative;
 }

--- a/Breakout/Ball.cpp
+++ b/Breakout/Ball.cpp
@@ -122,6 +122,16 @@ void Ball::setFireBall(float duration)
     _timeWithPowerupEffect = 0.f;    
 }
 
+void Ball::testBounce()
+{
+    _direction.x *= -1;
+}
+
+sf::Vector2f Ball::GetPosition()
+{
+    return _sprite.getPosition();
+}
+
 void Ball::IncreaseSpeed()
 {
     _velocityCumulative += (_velocityInitial * 0.1f );

--- a/Breakout/Ball.h
+++ b/Breakout/Ball.h
@@ -14,6 +14,8 @@ public:
     void render();
     void setVelocity(float coeff, float duration);
     void setFireBall(float duration);
+    void testBounce();
+    sf::Vector2f GetPosition();
 
 private:
     void IncreaseSpeed();

--- a/Breakout/Ball.h
+++ b/Breakout/Ball.h
@@ -16,10 +16,13 @@ public:
     void setFireBall(float duration);
 
 private:
+    void IncreaseSpeed();
     sf::CircleShape _sprite;
     sf::Vector2f _direction;
     sf::RenderWindow* _window;
     float _velocity;
+    float _velocityInitial;
+    float _velocityCumulative;
     bool _isAlive;
     bool _isFireBall;
     float _timeWithPowerupEffect;

--- a/Breakout/BallTrail.cpp
+++ b/Breakout/BallTrail.cpp
@@ -1,0 +1,65 @@
+#include "BallTrail.h"
+
+BallTrail::BallTrail() {
+	_timerCurrent = 0;
+	_flag = false;
+
+	for (int i = 0; i < _trailSize; i++) {
+		_trailActive.push_back(false);
+		_trailObject.push_back(TrailObject());
+	}
+}
+
+bool BallTrail::CheckTimer()
+{
+	if (!_flag) return false;
+
+	_flag = false;
+	return true;
+}
+
+int BallTrail::FirstInactiveTrail()
+{
+	for (int i = 0; i < _trailSize; i++) {
+		if (!_trailActive[i]) return i;
+	}
+	return -1;
+}
+
+void BallTrail::SpawnTrail(sf::Vector2f ballPosition)
+{
+	int slot = FirstInactiveTrail();
+	if (slot == -1) return;
+	_trailObject[slot].Spawn(_trailDuration, ballPosition);
+	_trailActive[slot] = true;
+}
+
+void BallTrail::Update(float dt, sf::Vector2f ball_position)
+{
+	_timerCurrent += dt;
+	if (_timerCurrent >= _timerLimit) {
+		_timerCurrent -= _timerLimit;
+		_flag = true;
+	}
+	if (CheckTimer()) {
+		SpawnTrail(ball_position);
+	}
+
+	//Update Trail Objects
+	for (int i = 0; i < _trailSize; i++) {
+		if (_trailActive[i])
+			if (_trailObject[i].Update(dt))
+				_trailActive[i] = false;
+	}
+}
+
+void BallTrail::Render(sf::RenderWindow* _window)
+{
+	for (int i = 0; i < _trailSize; i++) {
+		if(_trailActive[i])
+			_window->draw(_trailObject[i]._sprite);
+	}
+}
+
+
+

--- a/Breakout/BallTrail.h
+++ b/Breakout/BallTrail.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <vector>
+#include "TrailObject.h"
+
+class BallTrail
+{
+private:
+	
+	//Timers
+	float _timerCurrent;
+	float _timerLimit = 0.05f;
+	bool _flag = false;
+
+	//Trail Objects
+	float _trailDuration = 0.5f;
+	const int _trailSize = 16;
+	std::vector<bool> _trailActive;
+	std::vector<TrailObject> _trailObject;
+
+	bool CheckTimer();
+	int FirstInactiveTrail();
+	void SpawnTrail(sf::Vector2f ballPosition);
+
+public:
+	BallTrail();
+	void Update(float dt, sf::Vector2f ballPosition);
+	void Render(sf::RenderWindow* _window);
+
+};
+

--- a/Breakout/Breakout.vcxproj
+++ b/Breakout/Breakout.vcxproj
@@ -139,6 +139,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Ball.cpp" />
+    <ClCompile Include="BallTrail.cpp" />
     <ClCompile Include="Brick.cpp" />
     <ClCompile Include="BrickManager.cpp" />
     <ClCompile Include="GameManager.cpp" />
@@ -154,10 +155,12 @@
     <ClCompile Include="PowerupManager.cpp" />
     <ClCompile Include="PowerupSlowBall.cpp" />
     <ClCompile Include="PowerupSmallPaddle.cpp" />
+    <ClCompile Include="TrailObject.cpp" />
     <ClCompile Include="UI.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Ball.h" />
+    <ClInclude Include="BallTrail.h" />
     <ClInclude Include="Brick.h" />
     <ClInclude Include="BrickManager.h" />
     <ClInclude Include="CONSTANTS.h" />
@@ -171,6 +174,7 @@
     <ClInclude Include="PowerupManager.h" />
     <ClInclude Include="PowerupSlowBall.h" />
     <ClInclude Include="PowerupSmallPaddle.h" />
+    <ClInclude Include="TrailObject.h" />
     <ClInclude Include="UI.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Breakout/Breakout.vcxproj
+++ b/Breakout/Breakout.vcxproj
@@ -143,6 +143,7 @@
     <ClCompile Include="Brick.cpp" />
     <ClCompile Include="BrickManager.cpp" />
     <ClCompile Include="GameManager.cpp" />
+    <ClCompile Include="GameStateManager.cpp" />
     <ClCompile Include="main.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir)/SFML/include</AdditionalIncludeDirectories>
     </ClCompile>
@@ -165,6 +166,7 @@
     <ClInclude Include="BrickManager.h" />
     <ClInclude Include="CONSTANTS.h" />
     <ClInclude Include="GameManager.h" />
+    <ClInclude Include="GameStateManager.h" />
     <ClInclude Include="MessagingSystem.h" />
     <ClInclude Include="Paddle.h" />
     <ClInclude Include="PowerupBase.h" />

--- a/Breakout/Breakout.vcxproj.filters
+++ b/Breakout/Breakout.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClCompile Include="TrailObject.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="GameStateManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Ball.h">
@@ -120,6 +123,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="TrailObject.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GameStateManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Breakout/Breakout.vcxproj.filters
+++ b/Breakout/Breakout.vcxproj.filters
@@ -63,6 +63,12 @@
     <ClCompile Include="PowerupFireBall.cpp">
       <Filter>Powerups</Filter>
     </ClCompile>
+    <ClCompile Include="BallTrail.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="TrailObject.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Ball.h">
@@ -109,6 +115,12 @@
     </ClInclude>
     <ClInclude Include="PowerupFireBall.h">
       <Filter>Powerups</Filter>
+    </ClInclude>
+    <ClInclude Include="BallTrail.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="TrailObject.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Breakout/Brick.cpp
+++ b/Breakout/Brick.cpp
@@ -8,6 +8,11 @@ Brick::Brick(float x, float y, float width, float height)
     _shape.setFillColor(sf::Color::Red);
 }
 
+void Brick::move(sf::Vector2f vec)
+{
+    _shape.setPosition(_shape.getPosition() + vec);
+}
+
 void Brick::render(sf::RenderWindow& window)
 {
     if (!_isDestroyed) {
@@ -18,4 +23,9 @@ void Brick::render(sf::RenderWindow& window)
 sf::FloatRect Brick::getBounds() const
 {
     return _shape.getGlobalBounds();
+}
+
+bool Brick::GetDestroyed()
+{
+    return _isDestroyed;
 }

--- a/Breakout/Brick.h
+++ b/Breakout/Brick.h
@@ -4,8 +4,11 @@
 class Brick {
 public:
     Brick(float x, float y, float width, float height);
+    void move(sf::Vector2f vec);
     void render(sf::RenderWindow& window);
+    
     sf::FloatRect getBounds() const;
+    bool GetDestroyed();
 
 private:
     sf::RectangleShape _shape;

--- a/Breakout/BrickManager.cpp
+++ b/Breakout/BrickManager.cpp
@@ -23,6 +23,22 @@ void BrickManager::createBricks(int rows, int cols, float brickWidth, float bric
     }
 }
 
+void BrickManager::update(float dt)
+{
+    _moveTimer += dt;
+    if (_moveTimer > _moveLimit) {
+        _moveTimer -= _moveLimit;
+        _moveFlag = true;
+    }
+
+    if (_moveFlag) _speedX *= -1;
+    for (int i = 0; i < _bricks.size(); i++) {
+        _bricks[i].move(sf::Vector2f(_speedX, 0) * dt);
+        if(_moveFlag) _bricks[i].move(sf::Vector2f(0, _distY));
+    }
+    _moveFlag = false;
+}
+
 void BrickManager::render()
 {
     for (auto& brick : _bricks) {

--- a/Breakout/BrickManager.h
+++ b/Breakout/BrickManager.h
@@ -9,6 +9,7 @@ class BrickManager {
 public:
     BrickManager(sf::RenderWindow* window, GameManager* gameManager);
     void createBricks(int rows, int cols, float brickWidth, float brickHeight, float spacing);
+    void update(float dt);
     void render();
     int checkCollision(sf::CircleShape& ball, sf::Vector2f& direction);
 
@@ -18,4 +19,14 @@ private:
 
     GameManager* _gameManager;
     static constexpr float TOP_PADDING = 100.0f;
+
+    // Movement Data
+    bool _moveFlag = false;
+    float _speedX = 10;
+    float _distY = 0;
+    // Movement Timers
+    float _moveTimer = 5;
+    float _moveLimit = 10;
+
+
 };

--- a/Breakout/GameManager.cpp
+++ b/Breakout/GameManager.cpp
@@ -84,6 +84,8 @@ void GameManager::update(float dt)
     if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) _paddle->moveTo(dt, _window->mapPixelToCoords(sf::Mouse::getPosition()).x);
             
         
+    //BallTrail
+    _ballTrail.Update(dt, _ball->GetPosition());
     
 
     // update everything 
@@ -102,6 +104,7 @@ void GameManager::loseLife()
 
 void GameManager::render()
 {
+    _ballTrail.Render(_window);
     _paddle->render();
     _ball->render();
     _brickManager->render();

--- a/Breakout/GameManager.cpp
+++ b/Breakout/GameManager.cpp
@@ -77,9 +77,14 @@ void GameManager::update(float dt)
         _timeLastPowerupSpawned = _time;
     }
 
-    // move paddle
+    // Keyboard Paddle Movement
     if (sf::Keyboard::isKeyPressed(sf::Keyboard::D)) _paddle->moveRight(dt);
     if (sf::Keyboard::isKeyPressed(sf::Keyboard::A)) _paddle->moveLeft(dt);
+    // Mouse Paddle Movement
+    if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) _paddle->moveTo(dt, _window->mapPixelToCoords(sf::Mouse::getPosition()).x);
+            
+        
+    
 
     // update everything 
     _paddle->update(dt);

--- a/Breakout/GameManager.cpp
+++ b/Breakout/GameManager.cpp
@@ -91,6 +91,7 @@ void GameManager::update(float dt)
     // update everything 
     _paddle->update(dt);
     _ball->update(dt);
+    _brickManager->update(dt);
     _powerupManager->update(dt);
 }
 

--- a/Breakout/GameManager.cpp
+++ b/Breakout/GameManager.cpp
@@ -31,7 +31,7 @@ void GameManager::initialize()
 void GameManager::update(float dt)
 {
     _powerupInEffect = _powerupManager->getPowerupInEffect();
-    _ui->updatePowerupText(_powerupInEffect);
+    _ui->updatePowerup(_powerupInEffect);
     _powerupInEffect.second -= dt;
     
 

--- a/Breakout/GameManager.cpp
+++ b/Breakout/GameManager.cpp
@@ -15,12 +15,21 @@ GameManager::GameManager(sf::RenderWindow* window)
     _masterText.setFillColor(sf::Color::Yellow);
 }
 
+void GameManager::reset()
+{
+    _powerupInEffect = { none, 0 };
+    _timeLastPowerupSpawned = 0;
+    _lives = 3;
+    initialize();
+    
+}
+
 void GameManager::initialize()
 {
     _paddle = new Paddle(_window);
     _brickManager = new BrickManager(_window, this);
     _messagingSystem = new MessagingSystem(_window);
-    _ball = new Ball(_window, 400.0f, this); 
+    _ball = new Ball(_window, 400.0f, this);
     _powerupManager = new PowerupManager(_window, _paddle, _ball);
     _ui = new UI(_window, _lives, this);
 
@@ -37,7 +46,11 @@ void GameManager::update(float dt)
 
     if (_lives <= 0)
     {
-        _masterText.setString("Game over.");
+        _masterText.setString("Game over.\nSpace to Restart");
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::Space)) {
+            _masterText.setString(""); 
+            reset();
+        }
         return;
     }
     if (_levelComplete)

--- a/Breakout/GameManager.h
+++ b/Breakout/GameManager.h
@@ -14,6 +14,7 @@
 class GameManager {
 public:
     GameManager(sf::RenderWindow* window);
+    void reset();
     void initialize();
     void update(float dt);
     void loseLife();

--- a/Breakout/GameManager.h
+++ b/Breakout/GameManager.h
@@ -6,7 +6,7 @@
 #include "BrickManager.h"
 #include "PowerupManager.h"
 #include "MessagingSystem.h"
-#include "UI.h"
+#include "UI.h"#include "MouseInput.h"
 
 
 

--- a/Breakout/GameManager.h
+++ b/Breakout/GameManager.h
@@ -6,7 +6,8 @@
 #include "BrickManager.h"
 #include "PowerupManager.h"
 #include "MessagingSystem.h"
-#include "UI.h"#include "MouseInput.h"
+#include "UI.h"
+#include "BallTrail.h"
 
 
 
@@ -46,6 +47,8 @@ private:
     PowerupManager* _powerupManager;
     MessagingSystem* _messagingSystem;
     UI* _ui;
+
+    BallTrail _ballTrail;
 
     static constexpr float PAUSE_TIME_BUFFER = 0.5f;
     static constexpr float POWERUP_FREQUENCY = 7.5f;    // time between minimum powerup spawn

--- a/Breakout/GameStateManager.cpp
+++ b/Breakout/GameStateManager.cpp
@@ -1,0 +1,54 @@
+#include "GameStateManager.h"
+
+GameStateManager::GameStateManager()
+{
+	_currentState = Play;
+}
+
+GameStateManager::GameStateManager(GameManager* arg_gameManager)
+{
+	_currentState = Play;
+	_game = arg_gameManager;
+}
+
+void GameStateManager::update(float dt)
+{
+	switch (_currentState) {
+	case None: HandleNone(dt); break;
+	case Play: HandlePlay(dt); break;
+	case Pause: HandlePause(dt); break;
+	case Win: HandleWin(dt); break;
+	case Lose: HandleLose(dt); break;
+	}
+}
+
+GameState GameStateManager::GetCurrentState()
+{
+	return _currentState;
+}
+
+void GameStateManager::SetCurrentState(GameState arg_state)
+{
+	_currentState = arg_state;
+}
+
+void GameStateManager::HandleNone(float dt)
+{
+}
+
+void GameStateManager::HandlePlay(float dt)
+{
+	_game->update(dt);
+}
+
+void GameStateManager::HandlePause(float dt)
+{
+}
+
+void GameStateManager::HandleWin(float dt)
+{
+}
+
+void GameStateManager::HandleLose(float dt)
+{
+}

--- a/Breakout/GameStateManager.h
+++ b/Breakout/GameStateManager.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "GameManager.h"
+
+enum GameState { None, Play, Pause, Win, Lose };
+class GameStateManager
+{
+public:
+	GameStateManager();
+	GameStateManager(GameManager* arg_gameManager);
+	void update(float dt);
+	
+	GameState GetCurrentState();
+	void SetCurrentState(GameState arg_state);
+
+private:
+	GameState _currentState;
+	GameManager* _game;
+
+	void HandleNone(float dt);
+	void HandlePlay(float dt);
+	void HandlePause(float dt);
+	void HandleWin(float dt);
+	void HandleLose(float dt);
+
+};
+

--- a/Breakout/Paddle.cpp
+++ b/Breakout/Paddle.cpp
@@ -8,6 +8,8 @@ Paddle::Paddle(sf::RenderWindow* window)
     _sprite.setFillColor(sf::Color::Cyan);
     _sprite.setPosition((window->getSize().x - _width) / 2.0f, _height);
     _sprite.setSize(sf::Vector2f(_width, PADDLE_HEIGHT));
+    _sprite.setOutlineColor(sf::Color::Cyan);
+    _sprite.setOutlineThickness(0);
 }
 
 Paddle::~Paddle()
@@ -48,6 +50,7 @@ void Paddle::moveTo(float dt, float desiredX)
 
 void Paddle::update(float dt)
 {
+    UpdateCollisionResponse(dt);
     if (_timeInNewSize > 0)
     {
         _timeInNewSize -= dt;
@@ -77,4 +80,35 @@ void Paddle::setWidth(float coeff, float duration)
     _timeInNewSize = duration;
     float newX = _sprite.getPosition().x + (_width - PADDLE_WIDTH) / 2;
     _sprite.setPosition(newX, _sprite.getPosition().y);
+}
+
+void Paddle::CollisionWithBall()
+{
+    _collisionFlag = true;
+}
+
+void Paddle::UpdateCollisionResponse(float dt)
+{
+    if (_collisionFlag) {
+        _timerCurrent += dt;
+        if (_timerCurrent > _timerLimit) {
+            _timerCurrent -= _timerLimit;
+            _collisionFlag = false;
+        }
+        //Calculate Colour
+        float coeff = _timerCurrent / _timerLimit;
+        if (coeff > 1) coeff = 1;
+        float r = lerp(_collisionColour.r, sf::Color::Cyan.r, coeff);
+        float g = lerp(_collisionColour.g, sf::Color::Cyan.g, coeff);
+        float b = lerp(_collisionColour.b, sf::Color::Cyan.b, coeff);
+        _sprite.setFillColor(sf::Color(r,g,b));
+    }
+    else {
+        _sprite.setFillColor(sf::Color::Cyan);
+    }
+}
+
+float Paddle::lerp(float a, float b, float t)
+{
+    return (1.0f - t) * a + b * t;
 }

--- a/Breakout/Paddle.cpp
+++ b/Breakout/Paddle.cpp
@@ -4,8 +4,9 @@
 Paddle::Paddle(sf::RenderWindow* window)
     : _window(window), _width(PADDLE_WIDTH), _timeInNewSize(0.0f), _isAlive(true)
 {
+    _height = window->getSize().y - 50.0f;
     _sprite.setFillColor(sf::Color::Cyan);
-    _sprite.setPosition((window->getSize().x - _width) / 2.0f, window->getSize().y - 50.0f);
+    _sprite.setPosition((window->getSize().x - _width) / 2.0f, _height);
     _sprite.setSize(sf::Vector2f(_width, PADDLE_HEIGHT));
 }
 
@@ -17,7 +18,7 @@ void Paddle::moveLeft(float dt)
 {
     float position = _sprite.getPosition().x;
 
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::A) && position > 0)
+    if (position > 0)
     {
         _sprite.move(sf::Vector2f(-dt * PADDLE_SPEED, 0));
     }
@@ -27,10 +28,22 @@ void Paddle::moveRight(float dt)
 {
     float position = _sprite.getPosition().x;
 
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::D) && position < _window->getSize().x - _width)
+    if (position < _window->getSize().x - _width)
     {
         _sprite.move(sf::Vector2f(dt * PADDLE_SPEED, 0));
     }
+}
+
+void Paddle::moveTo(float dt, float desiredX)
+{
+    // Offset Desired Position for sprite size
+    desiredX -= 550;   
+    _sprite.setPosition(sf::Vector2f(desiredX, _height));
+    
+    // Alternate Control Scheme (Thats Feels Worse)
+    //float position = _sprite.getPosition().x;
+    //if (position > desiredX) _sprite.move(sf::Vector2f(-dt * PADDLE_SPEED, 0));
+    //if (position < desiredX) _sprite.move(sf::Vector2f(dt * PADDLE_SPEED, 0));
 }
 
 void Paddle::update(float dt)

--- a/Breakout/Paddle.cpp
+++ b/Breakout/Paddle.cpp
@@ -10,6 +10,7 @@ Paddle::Paddle(sf::RenderWindow* window)
     _sprite.setSize(sf::Vector2f(_width, PADDLE_HEIGHT));
     _sprite.setOutlineColor(sf::Color::Cyan);
     _sprite.setOutlineThickness(0);
+    _sprite.setScale(1, -1);
 }
 
 Paddle::~Paddle()
@@ -95,15 +96,22 @@ void Paddle::UpdateCollisionResponse(float dt)
             _timerCurrent -= _timerLimit;
             _collisionFlag = false;
         }
-        //Calculate Colour
         float coeff = _timerCurrent / _timerLimit;
         if (coeff > 1) coeff = 1;
+        
+        //Calculate Colour
         float r = lerp(_collisionColour.r, sf::Color::Cyan.r, coeff);
         float g = lerp(_collisionColour.g, sf::Color::Cyan.g, coeff);
         float b = lerp(_collisionColour.b, sf::Color::Cyan.b, coeff);
         _sprite.setFillColor(sf::Color(r,g,b));
+
+        //Calculate Scale
+        float x = lerp(_collisionScale.x, 1, coeff);
+        float y = lerp(_collisionScale.y, -1, coeff);
+        _sprite.setScale(sf::Vector2f(x, y));
     }
     else {
+        _sprite.setScale(sf::Vector2f(1, -1));
         _sprite.setFillColor(sf::Color::Cyan);
     }
 }

--- a/Breakout/Paddle.h
+++ b/Breakout/Paddle.h
@@ -33,6 +33,7 @@ private:
 
     bool _collisionFlag = false;
     sf::Color _collisionColour = sf::Color::Red;
+    sf::Vector2f _collisionScale = sf::Vector2f(1.f, -0.5f);
     float _timerCurrent = 0;
     float _timerLimit = 0.25f;
 };

--- a/Breakout/Paddle.h
+++ b/Breakout/Paddle.h
@@ -11,6 +11,7 @@ public:
 
     void moveLeft(float dt);
     void moveRight(float dt);
+    void moveTo(float dt, float desiredX);
     void update(float dt);
     void render();
     sf::FloatRect getBounds() const;
@@ -24,4 +25,5 @@ private:
     float _width = PADDLE_WIDTH;
     bool _isAlive;
     float _timeInNewSize = 0.0f;
+    float _height;
 };

--- a/Breakout/Paddle.h
+++ b/Breakout/Paddle.h
@@ -17,6 +17,10 @@ public:
     sf::FloatRect getBounds() const;
     void setWidth(float coeff, float duration);
 
+    void CollisionWithBall();
+    void UpdateCollisionResponse(float dt);
+    static float lerp(float a, float b, float t);
+
 private:
 
 
@@ -26,4 +30,9 @@ private:
     bool _isAlive;
     float _timeInNewSize = 0.0f;
     float _height;
+
+    bool _collisionFlag = false;
+    sf::Color _collisionColour = sf::Color::Red;
+    float _timerCurrent = 0;
+    float _timerLimit = 0.25f;
 };

--- a/Breakout/PowerupBase.h
+++ b/Breakout/PowerupBase.h
@@ -6,7 +6,7 @@
 #include "Ball.h"
 #include <vector>
 
-#include "PowerupFireBall.h"
+//#include "PowerupFireBall.h"
 
 
 class PowerupBase

--- a/Breakout/TrailObject.cpp
+++ b/Breakout/TrailObject.cpp
@@ -1,0 +1,24 @@
+#include "TrailObject.h"
+
+TrailObject::TrailObject()
+{
+	_sprite.setFillColor(sf::Color::White);
+	_sprite.setRadius(_radius);
+	_sprite.setPosition(sf::Vector2f(0, 0));
+	_timer = 1;
+}
+
+void TrailObject::Spawn(float duration, sf::Vector2f position)
+{
+	_timer = duration;
+	_sprite.setPosition(position);
+}
+
+bool TrailObject::Update(float dt)
+{
+	_timer -= dt;
+	_sprite.setRadius(_radius * _timer);
+	if (_timer > 0) 
+		return false;
+	return true;
+}

--- a/Breakout/TrailObject.h
+++ b/Breakout/TrailObject.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+
+class TrailObject
+{
+private:
+	
+	float _radius = 15;
+	float _timer;
+
+public:
+	sf::CircleShape _sprite;
+	TrailObject();
+	void Spawn(float duration, sf::Vector2f position);
+	bool Update(float dt);
+};
+

--- a/Breakout/UI.cpp
+++ b/Breakout/UI.cpp
@@ -18,10 +18,23 @@ UI::UI(sf::RenderWindow* window, int lives, GameManager* gameManager)
 		_lives.push_back(newLife);
 	}
 	_powerupText.setCharacterSize(30);
-	_powerupText.setPosition(800, 10);
+	_powerupText.setPosition(850, 700);
 	_powerupText.setFillColor(sf::Color::Cyan);
 	_font.loadFromFile("font/montS.ttf");
 	_powerupText.setFont(_font);
+
+	//PowerUp Bar
+	_bar.setPosition(950,700);
+	_bar.setFillColor(sf::Color::White);
+	_bar.setSize(sf::Vector2f(10, 200));
+	_bar.setScale(sf::Vector2f(1, -1));
+	_barBack.setPosition(950, 700);
+	_barBack.setSize(sf::Vector2f(10, 200));
+	_barBack.setScale(sf::Vector2f(1, -1));
+	_barBack.setFillColor(sf::Color::White);
+	_barBack.setOutlineColor(sf::Color::Cyan);
+	_barBack.setOutlineThickness(3);
+
 }
 
 UI::~UI()
@@ -29,9 +42,10 @@ UI::~UI()
 }
 
 
-void UI::updatePowerupText(std::pair<POWERUPS, float> powerup)
+void UI::updatePowerup(std::pair<POWERUPS, float> powerup)
 {
 	std::ostringstream oss;
+	_barActive = true;
 
 	switch (powerup.first)
 	{
@@ -39,32 +53,40 @@ void UI::updatePowerupText(std::pair<POWERUPS, float> powerup)
 		oss << std::fixed << std::setprecision(2) << powerup.second;
 		_powerupText.setString("big " + oss.str());
 		_powerupText.setFillColor(paddleEffectsColour);
+		_bar.setFillColor(paddleEffectsColour);
 		break;
 	case smallPaddle:
 		oss << std::fixed << std::setprecision(2) << powerup.second;
 		_powerupText.setString("small " + oss.str());
 		_powerupText.setFillColor(paddleEffectsColour);
+		_bar.setFillColor(paddleEffectsColour);
 		break;
 	case slowBall:
 		oss << std::fixed << std::setprecision(2) << powerup.second;
 		_powerupText.setString("slow " + oss.str());
 		_powerupText.setFillColor(ballEffectsColour);
+		_bar.setFillColor(ballEffectsColour);
 		break;
 	case fastBall:
 		oss << std::fixed << std::setprecision(2) << powerup.second;
 		_powerupText.setString("fast " + oss.str());
 		_powerupText.setFillColor(ballEffectsColour);
+		_bar.setFillColor(ballEffectsColour);
 		break;
 	case fireBall:
 		oss << std::fixed << std::setprecision(2) << powerup.second;
 		_powerupText.setString("fire " + oss.str());
 		_powerupText.setFillColor(extraBallEffectsColour);
+		_bar.setFillColor(extraBallEffectsColour);
 		break;
 	case none:
 		_powerupText.setString("");
-		
+		_barActive = false;
 		break;
 	}
+
+	_bar.setScale(1, -0.2 * powerup.second);
+
 }
 
 void UI::lifeLost(int lives)
@@ -75,6 +97,10 @@ void UI::lifeLost(int lives)
 void UI::render()
 {
 	_window->draw(_powerupText);
+	if (_barActive) {
+		_window->draw(_barBack);
+		_window->draw(_bar);
+	}
 	for (sf::CircleShape life : _lives)
 	{
 		_window->draw(life);

--- a/Breakout/UI.h
+++ b/Breakout/UI.h
@@ -13,7 +13,7 @@ public:
 	UI(sf::RenderWindow* window, int lives, GameManager* gameManager);
 	~UI();
 
-	void updatePowerupText(std::pair<POWERUPS, float>);
+	void updatePowerup(std::pair<POWERUPS, float>);
 	void lifeLost(int lives);
 	void render();
 
@@ -28,5 +28,10 @@ private:
 
 	static constexpr float LIFE_RADIUS = 15.0f;
 	static constexpr float LIFE_PADDING = 20.0f;
+
+	bool _barActive = false;
+	sf::RectangleShape _bar;
+	sf::RectangleShape _barBack;
+	
 };
 

--- a/Breakout/main.cpp
+++ b/Breakout/main.cpp
@@ -1,12 +1,14 @@
 #include <SFML/Graphics.hpp>
 #include "GameManager.h"
 #include <iostream>
+#include "GameStateManager.h"
 
 int main()
 {
 
     sf::RenderWindow window(sf::VideoMode(1000, 800), "Breakout");
     GameManager gameManager(&window);
+    GameStateManager gameState = GameStateManager(&gameManager);
     gameManager.initialize();
 
     sf::Clock clock;
@@ -23,7 +25,8 @@ int main()
 
         deltaTime = clock.restart().asSeconds();
 
-        gameManager.update(deltaTime);
+        gameState.update(deltaTime);
+        //gameManager.update(deltaTime);
 
         window.clear();
         gameManager.render();

--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ fire ball (green)
 [30 Minutes] Brick Movement: 	Bricks are moved from left to right based on a timer handled in the Brick Manager
 [20 Minutes] Ball Velocity: 	Ball Velocity Increases On Collision With the Paddle and Resets to Default when a Life is Lost
 [20 Minutes] Paddle Collision:	Paddle switches to red and lerps back to the default cyan colour over time
+[10 Minutes] Paddle Collision:	Paddle height scales to half and morphs back to full over time

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ fire ball (green)
 # Time Details and Changelist
 <Add information to this section about the time you've taken for this task along with a professional changelist.>
 
-[30 Seconds] Fixed by Removing Circular Dependency
-[20 Minutes] Paddle Moves directly to Mouse Position without Movement Speed
-[20 Minutes] Ball Velocity Increases On Collision With the Paddle and Resets to Default on Life Lost
-[60 Minutes] Added Ball Trail VFX
-[30 Minutes] Added Brick Left to Right Movement
-[30 Minutes] Added Powerup Bar
+[30 Seconds] Bug Fix: Removing Circular Dependency
+[20 Minutes] Mouse Movement added: Paddle Moves directly to Mouse Position without Movement Speed
+[60 Minutes] Ball Trail VFX: Sprites are spawned at regular at the balls position which decrease in size and then despawn
+[30 Minutes] Powerup Bar: Two sprites make up a bar that decreases as a powerup timer decreases
+[30 Minutes] Brick Movement: Bricks are moved from left to right based on a timer handled in the Brick Manager
+[20 Minutes] Ball Velocity: Ball Velocity Increases On Collision With the Paddle and Resets to Default when a Life is Lost
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ fire ball (green)
 [20 Minutes] Paddle Moves directly to Mouse Position without Movement Speed
 [20 Minutes] Ball Velocity Increases On Collision With the Paddle and Resets to Default on Life Lost
 [60 Minutes] Added Ball Trail VFX
+[30 Minutes] Added Brick Left to Right Movement

--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ fire ball (green)
 [20 Minutes] Paddle Moves directly to Mouse Position without Movement Speed
 [20 Minutes] Ball Velocity Increases On Collision With the Paddle and Resets to Default on Life Lost
 [60 Minutes] Added Ball Trail VFX
+[30 Minutes] Added Powerup Bar

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ fire ball (green)
 # Time Details and Changelist
 <Add information to this section about the time you've taken for this task along with a professional changelist.>
 
-[30 Seconds] Bug Fix:		Removing Circular Dependency
-[20 Minutes] Mouse Movement: 	Paddle Moves directly to Mouse Position without Movement Speed
-[60 Minutes] Ball Trail VFX:	Sprites are spawned at regular at the balls position which decrease in size and then despawn
-[30 Minutes] Powerup Bar: 	Two sprites make up a bar that decreases as a powerup timer decreases
-[30 Minutes] Brick Movement: 	Bricks are moved from left to right based on a timer handled in the Brick Manager
-[20 Minutes] Ball Velocity: 	Ball Velocity Increases On Collision With the Paddle and Resets to Default when a Life is Lost
-[20 Minutes] Paddle Collision:	Paddle switches to red and lerps back to the default cyan colour over time
-[10 Minutes] Paddle Collision:	Paddle height scales to half and morphs back to full over time
+*[30 Seconds] Bug Fix:		Removing Circular Dependency
+*[20 Minutes] Mouse Movement: 	Paddle Moves directly to Mouse Position without Movement Speed
+*[60 Minutes] Ball Trail VFX:	Sprites are spawned at regular at the balls position which decrease in size and then despawn
+*[30 Minutes] Powerup Bar: 	Two sprites make up a bar that decreases as a powerup timer decreases
+*[30 Minutes] Brick Movement: 	Bricks are moved from left to right based on a timer handled in the Brick Manager
+*[20 Minutes] Ball Velocity: 	Ball Velocity Increases On Collision With the Paddle and Resets to Default when a Life is Lost
+*[20 Minutes] Paddle Collision:	Paddle switches to red and lerps back to the default cyan colour over time
+*[10 Minutes] Paddle Collision:	Paddle height scales to half and morphs back to full over time

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ fire ball (green)
 # Time Details and Changelist
 <Add information to this section about the time you've taken for this task along with a professional changelist.>
 
-*[30 Seconds] Bug Fix:		Removing Circular Dependency
-*[20 Minutes] Mouse Movement: 	Paddle Moves directly to Mouse Position without Movement Speed
-*[60 Minutes] Ball Trail VFX:	Sprites are spawned at regular at the balls position which decrease in size and then despawn
-*[30 Minutes] Powerup Bar: 	Two sprites make up a bar that decreases as a powerup timer decreases
-*[30 Minutes] Brick Movement: 	Bricks are moved from left to right based on a timer handled in the Brick Manager
-*[20 Minutes] Ball Velocity: 	Ball Velocity Increases On Collision With the Paddle and Resets to Default when a Life is Lost
-*[20 Minutes] Paddle Collision:	Paddle switches to red and lerps back to the default cyan colour over time
-*[10 Minutes] Paddle Collision:	Paddle height scales to half and morphs back to full over time
+* [30 Seconds] Bug Fix:		Removing Circular Dependency
+* [20 Minutes] Mouse Movement: 	Paddle Moves directly to Mouse Position without Movement Speed
+* [60 Minutes] Ball Trail VFX:	Sprites are spawned at regular at the balls position which decrease in size and then despawn
+* [30 Minutes] Powerup Bar: 	Two sprites make up a bar that decreases as a powerup timer decreases
+* [30 Minutes] Brick Movement: 	Bricks are moved from left to right based on a timer handled in the Brick Manager
+* [20 Minutes] Ball Velocity: 	Ball Velocity Increases On Collision With the Paddle and Resets to Default when a Life is Lost
+* [20 Minutes] Paddle Collision:	Paddle switches to red and lerps back to the default cyan colour over time
+* [10 Minutes] Paddle Collision:	Paddle height scales to half and morphs back to full over time

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ fire ball (green)
 # Time Details and Changelist
 <Add information to this section about the time you've taken for this task along with a professional changelist.>
 
-[30 Seconds] Bug Fix: Removing Circular Dependency
-[20 Minutes] Mouse Movement added: Paddle Moves directly to Mouse Position without Movement Speed
-[60 Minutes] Ball Trail VFX: Sprites are spawned at regular at the balls position which decrease in size and then despawn
-[30 Minutes] Powerup Bar: Two sprites make up a bar that decreases as a powerup timer decreases
-[30 Minutes] Brick Movement: Bricks are moved from left to right based on a timer handled in the Brick Manager
-[20 Minutes] Ball Velocity: Ball Velocity Increases On Collision With the Paddle and Resets to Default when a Life is Lost
-
+[30 Seconds] Bug Fix:		Removing Circular Dependency
+[20 Minutes] Mouse Movement: 	Paddle Moves directly to Mouse Position without Movement Speed
+[60 Minutes] Ball Trail VFX:	Sprites are spawned at regular at the balls position which decrease in size and then despawn
+[30 Minutes] Powerup Bar: 	Two sprites make up a bar that decreases as a powerup timer decreases
+[30 Minutes] Brick Movement: 	Bricks are moved from left to right based on a timer handled in the Brick Manager
+[20 Minutes] Ball Velocity: 	Ball Velocity Increases On Collision With the Paddle and Resets to Default when a Life is Lost
+[20 Minutes] Paddle Collision:	Paddle switches to red and lerps back to the default cyan colour over time

--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ fire ball (green)
 
 [30 Seconds] Fixed by Removing Circular Dependency
 [20 Minutes] Paddle Moves directly to Mouse Position without Movement Speed
+[20 Minutes] Ball Velocity Increases On Collision With the Paddle and Resets to Default on Life Lost
+[60 Minutes] Added Ball Trail VFX

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ fire ball (green)
 
 * Fix the compiler issues in the code
 
+
 ## Suggested tasks
 
 * Implement mouse input for pad
@@ -33,3 +34,6 @@ fire ball (green)
 
 # Time Details and Changelist
 <Add information to this section about the time you've taken for this task along with a professional changelist.>
+
+[30 Seconds] Fixed by Removing Circular Dependency
+[20 Minutes] Paddle Moves directly to Mouse Position without Movement Speed


### PR DESCRIPTION
* [30 Seconds] Bug Fix:		Removing Circular Dependency
* [20 Minutes] Mouse Movement: 	Paddle Moves directly to Mouse Position without Movement Speed
* [60 Minutes] Ball Trail VFX:	Sprites are spawned at regular at the balls position which decrease in size and then despawn
* [30 Minutes] Powerup Bar: 	Two sprites make up a bar that decreases as a powerup timer decreases
* [30 Minutes] Brick Movement: 	Bricks are moved from left to right based on a timer handled in the Brick Manager
* [20 Minutes] Ball Velocity: 	Ball Velocity Increases On Collision With the Paddle and Resets to Default when a Life is Lost
* [20 Minutes] Paddle Collision:	Paddle switches to red and lerps back to the default cyan colour over time
* [10 Minutes] Paddle Collision:	Paddle height scales to half and morphs back to full over time