### PR TITLE
Update README.md

### DIFF
--- a/Breakout/Ball.cpp
+++ b/Breakout/Ball.cpp
@@ -70,6 +70,9 @@ void Ball::update(float dt)
     // collision with paddle
     if (_sprite.getGlobalBounds().intersects(_gameManager->getPaddle()->getBounds()))
     {
+        
+        _gameManager->getPaddle()->OnHit();
+
         _direction.y *= -1; // Bounce vertically
 
         float paddlePositionProportion = (_sprite.getPosition().x - _gameManager->getPaddle()->getBounds().left) / _gameManager->getPaddle()->getBounds().width;

--- a/Breakout/Paddle.cpp
+++ b/Breakout/Paddle.cpp
@@ -35,12 +35,12 @@ void Paddle::moveRight(float dt)
 
 void Paddle::update(float dt)
 {
-    sf::Vector2i mousePos = sf::Mouse::getPosition(*_window);
-    float mouseX = static_cast<float>(mousePos.x) - _width / 2.0f;
     
-    if (mouseX < _window->getSize().x - _width)
+    float mousePos = sf::Mouse::getPosition(*_window).x;
+    
+    if (mousePos < _window->getSize().x - _width)
     {
-        _sprite.setPosition(sf::Vector2f(mouseX,_sprite.getPosition().y));
+        _sprite.setPosition(sf::Vector2f(mousePos - _width/2.0f,_sprite.getPosition().y));
     }
     
     if (_timeInNewSize > 0)

--- a/Breakout/Paddle.cpp
+++ b/Breakout/Paddle.cpp
@@ -38,6 +38,15 @@ void Paddle::update(float dt)
     
     float mousePos = sf::Mouse::getPosition(*_window).x;
     
+    if (_hitFlashTime > 0.0f)
+    {
+        _hitFlashTime -= dt;
+        if (_hitFlashTime <= 0.0f)
+        {
+            _hitFlashTime = 0.0f;
+            _sprite.setFillColor(sf::Color::Cyan);
+        }
+    }
     if (mousePos < _window->getSize().x - _width)
     {
         _sprite.setPosition(sf::Vector2f(mousePos - _width/2.0f,_sprite.getPosition().y));
@@ -72,4 +81,10 @@ void Paddle::setWidth(float coeff, float duration)
     _timeInNewSize = duration;
     float newX = _sprite.getPosition().x + (_width - PADDLE_WIDTH) / 2;
     _sprite.setPosition(newX, _sprite.getPosition().y);
+}
+
+void Paddle::OnHit()
+{
+    _sprite.setFillColor(sf::Color::White);
+    _hitFlashTime = 0.15f;
 }

--- a/Breakout/Paddle.cpp
+++ b/Breakout/Paddle.cpp
@@ -35,6 +35,14 @@ void Paddle::moveRight(float dt)
 
 void Paddle::update(float dt)
 {
+    sf::Vector2i mousePos = sf::Mouse::getPosition(*_window);
+    float mouseX = static_cast<float>(mousePos.x) - _width / 2.0f;
+    
+    if (mouseX < _window->getSize().x - _width)
+    {
+        _sprite.setPosition(sf::Vector2f(mouseX,_sprite.getPosition().y));
+    }
+    
     if (_timeInNewSize > 0)
     {
         _timeInNewSize -= dt;

--- a/Breakout/Paddle.h
+++ b/Breakout/Paddle.h
@@ -15,6 +15,7 @@ public:
     void render();
     sf::FloatRect getBounds() const;
     void setWidth(float coeff, float duration);
+    void OnHit();
 
 private:
 
@@ -24,4 +25,5 @@ private:
     float _width = PADDLE_WIDTH;
     bool _isAlive;
     float _timeInNewSize = 0.0f;
+    float _hitFlashTime = 0.0f;
 };

--- a/Breakout/PowerupBase.h
+++ b/Breakout/PowerupBase.h
@@ -6,7 +6,7 @@
 #include "Ball.h"
 #include <vector>
 
-#include "PowerupFireBall.h"
+
 
 
 class PowerupBase

--- a/Breakout/PowerupFireBall.h
+++ b/Breakout/PowerupFireBall.h
@@ -8,5 +8,6 @@ public:
 
     std::pair<POWERUPS, float> applyEffect() override; // Method to apply the power-up effect
 
+    
 };
 

--- a/Breakout/UI.cpp
+++ b/Breakout/UI.cpp
@@ -22,6 +22,21 @@ UI::UI(sf::RenderWindow* window, int lives, GameManager* gameManager)
 	_powerupText.setFillColor(sf::Color::Cyan);
 	_font.loadFromFile("font/montS.ttf");
 	_powerupText.setFont(_font);
+
+	//Powerup progress bar setup
+	_powerupBarMaxWidth = 200.f;
+	_maxPowerupTime = 0.f;
+	_currentPowerupTime = 0.f;
+
+	_powerupBarBackground.setSize(sf::Vector2f(_powerupBarMaxWidth, 20.f));
+	_powerupBarBackground.setFillColor(sf::Color::White);
+	_powerupBarBackground.setOutlineColor(sf::Color::Cyan);
+	_powerupBarBackground.setOutlineThickness(2.f);
+	_powerupBarBackground.setPosition(790.f, 50.f);
+
+	_powerupBarFill.setSize(sf::Vector2f(_powerupBarMaxWidth, 20.f));
+	//_powerupBarFill.setFillColor(sf::Color::Green);
+	_powerupBarFill.setPosition(790.f, 50.f);
 }
 
 UI::~UI()
@@ -33,35 +48,53 @@ void UI::updatePowerupText(std::pair<POWERUPS, float> powerup)
 {
 	std::ostringstream oss;
 
+	if (_maxPowerupTime == 0.f)
+	{
+		_maxPowerupTime = powerup.second;
+	}
+
+	_currentPowerupTime = powerup.second;
+
+	float powerupProgress = _currentPowerupTime / _maxPowerupTime;
+	powerupProgress = std::max(0.f, std::min(1.f, powerupProgress));
+
+	_powerupBarFill.setSize(sf::Vector2f(_powerupBarMaxWidth * powerupProgress, 20.f));
+
 	switch (powerup.first)
 	{
 	case bigPaddle:
 		oss << std::fixed << std::setprecision(2) << powerup.second;
 		_powerupText.setString("big " + oss.str());
 		_powerupText.setFillColor(paddleEffectsColour);
+		_powerupBarFill.setFillColor(paddleEffectsColour);
 		break;
 	case smallPaddle:
 		oss << std::fixed << std::setprecision(2) << powerup.second;
 		_powerupText.setString("small " + oss.str());
 		_powerupText.setFillColor(paddleEffectsColour);
+		_powerupBarFill.setFillColor(paddleEffectsColour);
 		break;
 	case slowBall:
 		oss << std::fixed << std::setprecision(2) << powerup.second;
 		_powerupText.setString("slow " + oss.str());
 		_powerupText.setFillColor(ballEffectsColour);
+		_powerupBarFill.setFillColor(ballEffectsColour);
 		break;
 	case fastBall:
 		oss << std::fixed << std::setprecision(2) << powerup.second;
 		_powerupText.setString("fast " + oss.str());
 		_powerupText.setFillColor(ballEffectsColour);
+		_powerupBarFill.setFillColor(ballEffectsColour);
 		break;
 	case fireBall:
 		oss << std::fixed << std::setprecision(2) << powerup.second;
 		_powerupText.setString("fire " + oss.str());
 		_powerupText.setFillColor(extraBallEffectsColour);
+		_powerupBarFill.setFillColor(extraBallEffectsColour);
 		break;
 	case none:
 		_powerupText.setString("");
+		_powerupBarFill.setSize(sf::Vector2f(0.f, 20.f));
 		
 		break;
 	}
@@ -79,4 +112,6 @@ void UI::render()
 	{
 		_window->draw(life);
 	}
+	_window->draw(_powerupBarBackground);
+	_window->draw(_powerupBarFill);
 }

--- a/Breakout/UI.h
+++ b/Breakout/UI.h
@@ -23,6 +23,12 @@ private:
 	sf::RenderWindow* _window;
 	sf::Font _font;
 	sf::Text _powerupText;
+	sf::RectangleShape _powerupBarBackground;
+	sf::RectangleShape _powerupBarFill;
+
+	float _powerupBarMaxWidth;
+	float _currentPowerupTime;
+	float _maxPowerupTime;
 
 	std::vector<sf::CircleShape> _lives;
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ fire ball (green)
 Time Details
 
 * Fixed compiler error: 10mins
+* Added Mouse control for paddle: 40mins
 * 
 
 
@@ -47,3 +48,5 @@ Time Details
 Changelist
 
 * Fixed Compiler error by removing PowerupFireBall.h from PowerupBase header file
+* Added Mouse control for paddle using sf::Mouse::getPosition(\*\_window) then realised can just use sf::Mouse::getPosition(\*\_window).x
+* 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Breakout
 
-W Kavanagh & N Merchant. Summer 2024 
+W Kavanagh \& N Merchant. Summer 2024
 
 ## controls
 
@@ -27,9 +27,23 @@ fire ball (green)
 * GameLoop
 * Better ball physics (Box2D)
 * Leaderboards
-* More ball types (e.g., multiball, sticky ball [where you shoot the ball from the paddle every time], tiny ball, big ball, brick-tracking ball)
+* More ball types (e.g., multiball, sticky ball \[where you shoot the ball from the paddle every time], tiny ball, big ball, brick-tracking ball)
 * Sounds with increasing tone between bounces.
 * Implement commentary with calls to an LLM such as LLama
 
 # Time Details and Changelist
+
 <Add information to this section about the time you've taken for this task along with a professional changelist.>
+
+
+
+Time Details
+
+* Fixed compiler error: 10mins
+* 
+
+
+
+Changelist
+
+* Fixed Compiler error by removing PowerupFireBall.h from PowerupBase header file

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Time Details
 
 * Fixed compiler error: 10mins
 * Added Mouse control for paddle: 40mins
-* 
+* Added Progress bar for powerups: 1hr 15mins
+* Total time: 2hrs 5mins
 
 
 
@@ -49,4 +50,7 @@ Changelist
 
 * Fixed Compiler error by removing PowerupFireBall.h from PowerupBase header file
 * Added Mouse control for paddle using sf::Mouse::getPosition(\*\_window) then realised can just use sf::Mouse::getPosition(\*\_window).x
-* 
+* Added Progress bar for powerups by creating a rectangle for the background and a fill rectangle that scales with the time remaining of the powerup
+
+
+


### PR DESCRIPTION
Changelist
⦁	Fixed Compiler error by removing PowerupFireBall.h from PowerupBase header file
⦁	Added Mouse control for paddle using sf::Mouse::getPosition(*_window) then realised can just use sf::Mouse::getPosition(*_window).x
⦁	Added Progress bar for powerups by creating a rectangle for the background and a fill rectangle that scales with the time remaining of the powerup
